### PR TITLE
Use https for submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "patternlab-php"]
 	path = patternlab-php
-	url = git@github.com:pattern-lab/patternlab-php.git
+	url = https://github.com/pattern-lab/patternlab-php.git


### PR DESCRIPTION
Switches the submodule URL for `patternlab-php` from ssh to https.

Using https will allow Dependabot to update repos that use this gem. (Dependabot really ought to be able to support ssh URLs, too, but adding support for them will take a while longer.)

You'll need to `bundle update patternlab` in the repos that use the dependency to get an updated Gemfile.lock for them, pulling in the change.